### PR TITLE
Refactors Build and CI to Use Nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,5 @@ jobs:
 
       - uses: DeterminateSystems/magic-nix-cache-action@v13
 
-      - run: make gomod2nix.toml
+      - run: nix develop -c make gomod2nix.toml
       - run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         run: sudo modprobe wireguard
 
       - name: Test (in container)
-        run: make test-container
+        run: make test-privileged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,45 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: cachix/install-nix-action@v31.10.1
         with:
-          go-version-file: go.mod
-          cache: true
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Load WireGuard kernel module
-        run: sudo modprobe wireguard
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
 
-      - name: Test (in container)
-        run: make test-privileged
+      - run: make build
+
+  container-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: docker/setup-docker-action@v5.0.0
+
+      - run: sudo modprobe wireguard
+      - run: make test-privileged
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: cachix/install-nix-action@v31.10.1
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      - run: make check
+
+  clean:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: cachix/install-nix-action@v31.10.1
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      - run: make gomod2nix.toml
+      - run: git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 .claude/*
 wireguard-cni
 *cover*
+/result

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,18 @@ load: bin/stream-image.sh
 format fmt:
 	nix fmt
 
+check:
+	nix flake check
+
 # Run all tests inside a privileged Docker container (no sudo required)
-test-container:
+test-privileged:
 	$(DOCKER) run --rm \
 	  --privileged \
 	  -v "$(CURDIR):/src" \
 	  -v "$(GOPATH)/pkg/mod:/go/pkg/mod" \
 	  -w /src \
 	  $(GO_IMAGE) \
-	  $(GO) test -v ./...
+	  go test -v ./...
 
 go.sum: go.mod ${GO_SRC}
 	$(GO) mod tidy

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-DOCKER ?= docker
-GINKGO ?= ginkgo
-GO     ?= go
+DOCKER    ?= docker
+GINKGO    ?= ginkgo
+GO        ?= go
+GOMOD2NIX ?= gomod2nix
 
-GOVERSION ?= $(shell go env GOVERSION | sed 's/go//')
+GOVERSION ?= $(shell $(GO) env GOVERSION | sed 's/go//')
 GO_IMAGE  ?= golang:$(GOVERSION)
-GOPATH    ?= $(shell go env GOPATH)
+GOPATH    ?= $(shell $(GO) env GOPATH)
 
 GO_SRC := $(shell find . -name '*.go')
 

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ go.sum: go.mod ${GO_SRC}
 gomod2nix.toml: go.sum
 	$(GOMOD2NIX) generate
 
-bin/wireguard-cni: ${GO_SRC}
-	$(GO) build -o $@ .
+bin/wireguard-cni: | result/bin/wireguard-cni
+	mkdir -p ${@D} && ln -sf ${CURDIR}/$| ${CURDIR}/$@
 
 bin/stream-image.sh: ${GO_SRC}
 	nix build .#ctr --out-link $@
@@ -54,3 +54,6 @@ bin/image.tar.gz: bin/stream-image.sh
 
 coverprofile.out: ${GO_SRC}
 	$(GINKGO) run -r --cover --label-filter="!integration"
+
+result/bin/wireguard-cni: ${GO_SRC}
+	nix build .#wireguard-cni

--- a/flake.nix
+++ b/flake.nix
@@ -96,8 +96,9 @@
           };
 
           treefmt.programs = {
-            nixfmt.enable = true;
+            actionlint.enable = true;
             gofmt.enable = true;
+            nixfmt.enable = true;
           };
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -39,12 +39,13 @@
         let
           inherit (inputs'.gomod2nix.legacyPackages) buildGoApplication;
 
-          go = pkgs.go_1_26;
+          gopkg = pkgs.go_1_26;
           version = "0.0.1";
           wireguard-cni = buildGoApplication {
             pname = "wireguard-cni";
-            inherit version go;
+            inherit version;
 
+            go = gopkg;
             src = lib.cleanSource ./.;
             modules = ./gomod2nix.toml;
 
@@ -85,17 +86,17 @@
             packages = with pkgs; [
               docker
               ginkgo
-              go
+              gopkg
               gomod2nix
               nixfmt
             ];
 
             DOCKER = "${pkgs.docker}/bin/docker";
             GINKGO = "${pkgs.ginkgo}/bin/ginkgo";
-            GO = "${go}/bin/go";
+            GO = "${gopkg}/bin/go";
             GOMOD2NIX = "${pkgs.gomod2nix}/bin/gomod2nix";
 
-            GOVERSION = go.version;
+            GOVERSION = gopkg.version;
           };
 
           treefmt.programs = {

--- a/flake.nix
+++ b/flake.nix
@@ -39,10 +39,11 @@
         let
           inherit (inputs'.gomod2nix.legacyPackages) buildGoApplication;
 
+          go = pkgs.go_1_26;
           version = "0.0.1";
           wireguard-cni = buildGoApplication {
             pname = "wireguard-cni";
-            inherit version;
+            inherit version go;
 
             src = lib.cleanSource ./.;
             modules = ./gomod2nix.toml;
@@ -91,8 +92,10 @@
 
             DOCKER = "${pkgs.docker}/bin/docker";
             GINKGO = "${pkgs.ginkgo}/bin/ginkgo";
-            GO = "${pkgs.go}/bin/go";
+            GO = "${go}/bin/go";
             GOMOD2NIX = "${pkgs.gomod2nix}/bin/gomod2nix";
+
+            GOVERSION = go.version;
           };
 
           treefmt.programs = {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/unstoppablemango/wireguard-cni
 
-go 1.25.1
+go 1.26.1
 
 require (
 	github.com/containernetworking/cni v1.3.0


### PR DESCRIPTION
Refactors the project's build system and continuous integration (CI) workflows to leverage Nix for enhanced reproducibility, consistency, and caching.

*   Migrates GitHub Actions to use `install-nix-action` and `magic-nix-cache-action` for dependency management and caching across all jobs.
*   Updates the `Makefile` to build the `wireguard-cni` binary using `nix build`, consolidating the build process.
*   Introduces new dedicated CI jobs for:
    *   `container-test`: Isolates container-based tests.
    *   `check`: Runs project-wide checks with Nix.
    *   `clean`: Ensures flake hygiene by verifying `gomod2nix.toml` consistency.
*   Configures `flake.nix` to explicitly define the Go version for builds, ensuring consistent environments.