### PR TITLE
Adds iproute2 package to tools

### DIFF
--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -2,6 +2,7 @@
   bash,
   buildEnv,
   dockerTools,
+  iproute2,
   netcat,
   uutils-coreutils-noprefix,
   wireguard-tools,
@@ -14,6 +15,7 @@ dockerTools.streamLayeredImage {
     name = "image-root";
     paths = [
       bash
+      iproute2
       netcat
       uutils-coreutils-noprefix
       wireguard-tools


### PR DESCRIPTION
Includes essential network configuration utilities like `ip` and `ss` within the image root for enhanced debugging and management capabilities.
