### PR TITLE
feat: remove non-standard isolated field

### DIFF
--- a/pkg/cmd/cni.go
+++ b/pkg/cmd/cni.go
@@ -10,7 +10,6 @@ import (
 const Name = "wireguard-cni"
 
 var (
-	ErrIsolated       = fmt.Errorf("%s: isolated mode does not accept a prevResult", Name)
 	ErrPrevResult     = fmt.Errorf("%s: CHECK requires a prevResult from a prior ADD", Name)
 	ErrChainedVersion = fmt.Errorf("%s: chained mode requires CNI spec >= 0.3.0", Name)
 )

--- a/pkg/cmd/cni_linux.go
+++ b/pkg/cmd/cni_linux.go
@@ -19,10 +19,7 @@ func Add(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	if conf.Isolated && conf.PrevResult != nil {
-		return ErrIsolated
-	}
-	if !conf.Isolated && conf.PrevResult != nil {
+	if conf.PrevResult != nil {
 		if ok, err := version.GreaterThanOrEqualTo(conf.CNIVersion, "0.3.0"); err != nil || !ok {
 			return errors.Join(ErrChainedVersion, err)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,6 @@ type Config struct {
 	Address    string       `json:"address"`
 	PrivateKey string       `json:"privateKey"`
 	ListenPort int          `json:"listenPort,omitempty"`
-	Isolated   bool         `json:"isolated,omitempty"`
 	Peers      []PeerConfig `json:"peers"`
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -64,17 +64,12 @@ func addDefaultRouteInNS(targetNS ns.NetNS, gateway, viaIface string) {
 // newNetConf builds a CNI ADD config for the wireguard-cni plugin. Pass a
 // non-nil prevResult to produce a config suitable for CNI CHECK.
 func newNetConf(privKey, peerPubKey wgtypes.Key, address, version string, prevResult []byte) []byte {
-	return newNetConfFull(privKey, peerPubKey, address, version, prevResult, false)
-}
-
-func newNetConfFull(privKey, peerPubKey wgtypes.Key, address, version string, prevResult []byte, isolated bool) []byte {
 	conf := map[string]any{
 		"cniVersion": version,
 		"name":       "wg-test",
 		"type":       "wireguard-cni",
 		"address":    address,
 		"privateKey": privKey.String(),
-		"isolated":   isolated,
 		"peers": []map[string]any{{
 			"publicKey":  peerPubKey.String(),
 			"allowedIPs": []string{"10.0.0.0/8"},
@@ -225,7 +220,7 @@ var _ = Describe("Host interface configuration", func() {
 	}
 })
 
-var _ = Describe("Isolated mode", Label("e2e"), func() {
+var _ = Describe("Chained mode", Label("e2e"), func() {
 	for _, ver := range testutils.AllSpecVersions {
 		// CNI 0.1.0 and 0.2.0 predate chained mode; their result type has no
 		// Interfaces field, so prevResult-based tests don't apply.
@@ -233,48 +228,7 @@ var _ = Describe("Isolated mode", Label("e2e"), func() {
 			continue
 		}
 		Describe(fmt.Sprintf("cni %s", ver), Label(ver), func() {
-			It("ADD with isolated:true and a prevResult returns an error", func() {
-				testNS, err := testutils.NewNS()
-				Expect(err).NotTo(HaveOccurred())
-				DeferCleanup(func() {
-					_ = cmd.Del(&skel.CmdArgs{Netns: testNS.Path(), IfName: "wg0"})
-					testNS.Close()
-					testutils.UnmountNS(testNS)
-				})
-
-				privKey, err := wgtypes.GeneratePrivateKey()
-				Expect(err).NotTo(HaveOccurred())
-				peerKey, err := wgtypes.GeneratePrivateKey()
-				Expect(err).NotTo(HaveOccurred())
-
-				// First do an ADD to get a valid prevResult.
-				addArgs := &skel.CmdArgs{
-					ContainerID: "test-isolated",
-					Netns:       testNS.Path(),
-					IfName:      "wg0",
-					Path:        "/opt/cni/bin",
-					StdinData:   newNetConf(privKey, peerKey.PublicKey(), "10.101.0.2/24", ver, nil),
-				}
-				_, prevResult, err := testutils.CmdAddWithArgs(addArgs, func() error {
-					return cmd.Add(addArgs)
-				})
-				Expect(err).NotTo(HaveOccurred())
-
-				// Now attempt ADD with isolated:true and a non-nil prevResult.
-				isolatedArgs := &skel.CmdArgs{
-					ContainerID: "test-isolated",
-					Netns:       testNS.Path(),
-					IfName:      "wg1",
-					Path:        "/opt/cni/bin",
-					StdinData:   newNetConfFull(privKey, peerKey.PublicKey(), "10.101.1.2/24", ver, prevResult, true),
-				}
-				_, _, err = testutils.CmdAddWithArgs(isolatedArgs, func() error {
-					return cmd.Add(isolatedArgs)
-				})
-				Expect(err).To(MatchError(ContainSubstring("isolated mode does not accept a prevResult")))
-			})
-
-			It("ADD with isolated:false (default) and a prevResult succeeds and returns merged result", func() {
+			It("ADD with a prevResult succeeds and returns merged result", func() {
 				testNS, err := testutils.NewNS()
 				Expect(err).NotTo(HaveOccurred())
 				DeferCleanup(func() {
@@ -308,7 +262,7 @@ var _ = Describe("Isolated mode", Label("e2e"), func() {
 					Netns:       testNS.Path(),
 					IfName:      "wg1",
 					Path:        "/opt/cni/bin",
-					StdinData:   newNetConfFull(privKey, peerKey.PublicKey(), "10.102.1.2/24", ver, prevResult, false),
+					StdinData:   newNetConf(privKey, peerKey.PublicKey(), "10.102.1.2/24", ver, prevResult),
 				}
 				_, chainedResult, err := testutils.CmdAddWithArgs(chainedArgs, func() error {
 					return cmd.Add(chainedArgs)


### PR DESCRIPTION
The isolated field had no equivalent in the CNI conventions and was
invisible to runtimes. Standard CNI behavior is to unconditionally
accept prevResult; the version guard for CNI >= 0.3.0 is retained.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
