### PR TITLE
feat: validate prevResult contents in Check

### DIFF
--- a/pkg/cmd/cni_linux.go
+++ b/pkg/cmd/cni_linux.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
+	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/unstoppablemango/wireguard-cni/pkg/config"
 	"github.com/unstoppablemango/wireguard-cni/pkg/network"
@@ -55,7 +56,12 @@ func Check(args *skel.CmdArgs) error {
 		return ErrPrevResult
 	}
 
+	prev, err := current.GetResult(conf.PrevResult)
+	if err != nil {
+		return err
+	}
+
 	return ns.WithNetNSPath(args.Netns, func(ns.NetNS) error {
-		return wireguard.Check(network.New(args.IfName), conf)
+		return wireguard.Check(network.New(args.IfName), conf, args.IfName, prev)
 	})
 }

--- a/pkg/cmd/cni_linux.go
+++ b/pkg/cmd/cni_linux.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	"github.com/containernetworking/cni/pkg/version"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/unstoppablemango/wireguard-cni/pkg/config"
 	"github.com/unstoppablemango/wireguard-cni/pkg/network"

--- a/pkg/cmd/cni_linux.go
+++ b/pkg/cmd/cni_linux.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	current "github.com/containernetworking/cni/pkg/types/100"
@@ -58,7 +59,7 @@ func Check(args *skel.CmdArgs) error {
 
 	prev, err := current.GetResult(conf.PrevResult)
 	if err != nil {
-		return err
+		return fmt.Errorf("get prevResult: %w", err)
 	}
 
 	return ns.WithNetNSPath(args.Netns, func(ns.NetNS) error {

--- a/pkg/config/wireguard.go
+++ b/pkg/config/wireguard.go
@@ -8,15 +8,20 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-func (c *Config) Wireguard() (*net.IPNet, *wgtypes.Config, error) {
+func (c *Config) Wireguard() ([]*net.IPNet, *wgtypes.Config, error) {
 	if len(c.RuntimeConfig.IPs) == 0 {
 		return nil, nil, fmt.Errorf("runtimeConfig.ips is required")
 	}
-	ip, addr, err := net.ParseCIDR(c.RuntimeConfig.IPs[0])
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid runtimeConfig.ips[0]: %w", err)
+
+	var addrs []*net.IPNet
+	for i, ipStr := range c.RuntimeConfig.IPs {
+		ip, addr, err := net.ParseCIDR(ipStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid runtimeConfig.ips[%d]: %w", i, err)
+		}
+		addr.IP = ip
+		addrs = append(addrs, addr)
 	}
-	addr.IP = ip
 
 	if c.PrivateKey == "" {
 		return nil, nil, fmt.Errorf("privateKey is required")
@@ -42,7 +47,7 @@ func (c *Config) Wireguard() (*net.IPNet, *wgtypes.Config, error) {
 		wg.Peers = append(wg.Peers, *pc)
 	}
 
-	return addr, &wg, nil
+	return addrs, &wg, nil
 }
 
 func peerConfig(c PeerConfig) (*wgtypes.PeerConfig, error) {

--- a/pkg/config/wireguard_test.go
+++ b/pkg/config/wireguard_test.go
@@ -82,14 +82,16 @@ var _ = Describe("Wireguard", func() {
 		Expect(err).To(MatchError(ContainSubstring("invalid runtimeConfig.ips[0]")))
 	})
 
-	It("uses only the first IP when multiple are provided", func() {
+	It("returns all IPs when multiple are provided", func() {
 		key, err := wgtypes.GeneratePrivateKey()
 		Expect(err).NotTo(HaveOccurred())
 		conf := configWithIPs("10.0.0.1/24", "10.0.0.2/24")
 		conf.PrivateKey = key.String()
 
-		addr, _, err := conf.Wireguard()
+		addrs, _, err := conf.Wireguard()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(addr.IP.String()).To(Equal("10.0.0.1"))
+		Expect(addrs).To(HaveLen(2))
+		Expect(addrs[0].IP.String()).To(Equal("10.0.0.1"))
+		Expect(addrs[1].IP.String()).To(Equal("10.0.0.2"))
 	})
 })

--- a/pkg/network/link.go
+++ b/pkg/network/link.go
@@ -30,6 +30,8 @@ type Link interface {
 	ConfigureWireGuard(conf wgtypes.Config) error
 	// PublicKey returns the public key currently set on the WireGuard device.
 	PublicKey() (wgtypes.Key, error)
+	// Routes returns all routes currently installed via this link.
+	Routes() ([]*net.IPNet, error)
 }
 
 // LinkManager manages a single named network link. The link name is

--- a/pkg/network/linux.go
+++ b/pkg/network/linux.go
@@ -110,3 +110,17 @@ func (l *netlinkLink) Addresses() ([]*net.IPNet, error) {
 	}
 	return result, nil
 }
+
+func (l *netlinkLink) Routes() ([]*net.IPNet, error) {
+	routes, err := netlink.RouteList(l.link, netlink.FAMILY_ALL)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*net.IPNet, 0, len(routes))
+	for _, r := range routes {
+		if r.Dst != nil {
+			result = append(result, r.Dst)
+		}
+	}
+	return result, nil
+}

--- a/pkg/network/linux.go
+++ b/pkg/network/linux.go
@@ -120,7 +120,24 @@ func (l *netlinkLink) Routes() ([]*net.IPNet, error) {
 	for _, r := range routes {
 		if r.Dst != nil {
 			result = append(result, r.Dst)
+			continue
 		}
+		// In netlink, a nil Dst represents a default route.
+		// Map to an explicit /0 network based on the route family.
+		var cidr string
+		switch r.Family {
+		case netlink.FAMILY_V4:
+			cidr = "0.0.0.0/0"
+		case netlink.FAMILY_V6:
+			cidr = "::/0"
+		default:
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			continue
+		}
+		result = append(result, ipNet)
 	}
 	return result, nil
 }

--- a/pkg/wireguard/fake_test.go
+++ b/pkg/wireguard/fake_test.go
@@ -65,6 +65,9 @@ func (f *fakeLink) Routes() ([]*net.IPNet, error) {
 }
 
 func (f *fakeLink) String() string {
+	if f.assignedAddr == nil || f.assignedAddr.IP == nil {
+		return "fake(<unassigned>)"
+	}
 	return fmt.Sprintf("fake(%s)", f.assignedAddr.IP)
 }
 

--- a/pkg/wireguard/fake_test.go
+++ b/pkg/wireguard/fake_test.go
@@ -23,6 +23,8 @@ type fakeLink struct {
 	addresses             []*net.IPNet
 	publicKeyErr          error
 	publicKey             wgtypes.Key
+	routesErr             error
+	routes                []*net.IPNet
 
 	assignedAddr   *net.IPNet
 	configuredConf *wgtypes.Config
@@ -56,6 +58,10 @@ func (f *fakeLink) Addresses() ([]*net.IPNet, error) {
 
 func (f *fakeLink) PublicKey() (wgtypes.Key, error) {
 	return f.publicKey, f.publicKeyErr
+}
+
+func (f *fakeLink) Routes() ([]*net.IPNet, error) {
+	return f.routes, f.routesErr
 }
 
 func (f *fakeLink) String() string {

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Add(mgr network.LinkManager, conf *config.Config) error {
-	addr, wg, err := conf.Wireguard()
+	addrs, wg, err := conf.Wireguard()
 	if err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
@@ -129,10 +129,12 @@ func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResu
 	return nil
 }
 
-func setup(link network.Link, addr *net.IPNet, conf *wgtypes.Config) error {
-	zap.L().Info("assigning address", zap.String("address", addr.String()))
-	if err := link.AssignAddress(addr); err != nil {
-		return fmt.Errorf("assign address %v: %w", addr, err)
+func setup(link network.Link, addrs []*net.IPNet, conf *wgtypes.Config) error {
+	for _, addr := range addrs {
+		zap.L().Info("assigning address", zap.String("address", addr.String()))
+		if err := link.AssignAddress(addr); err != nil {
+			return fmt.Errorf("assign address %v: %w", addr, err)
+		}
 	}
 	return applyConfig(link, conf)
 }

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"slices"
 
+	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/unstoppablemango/wireguard-cni/pkg/config"
 	"github.com/unstoppablemango/wireguard-cni/pkg/network"
 	"go.uber.org/zap"
@@ -48,11 +49,12 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 	return nil
 }
 
-// Check verifies that the WireGuard interface exists, has the configured address,
-// and that the device public key matches the configured private key.
+// Check verifies that the WireGuard interface exists, that all IPs and routes
+// from prevResult are still present in the live network namespace, and that the
+// device public key matches the configured private key.
 // Must be called from within an ns.Do() closure.
-func Check(mgr network.LinkManager, conf *config.Config) error {
-	addr, wg, err := conf.Wireguard()
+func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResult *current.Result) error {
+	_, wg, err := conf.Wireguard()
 	if err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
@@ -61,15 +63,46 @@ func Check(mgr network.LinkManager, conf *config.Config) error {
 		return fmt.Errorf("check link: %w", err)
 	}
 
-	zap.L().Info("checking link address", zap.String("expected", addr.String()))
+	// Find our interface index in prevResult.
+	ifIdx := -1
+	for i, iface := range prevResult.Interfaces {
+		if iface.Name == ifName {
+			ifIdx = i
+			break
+		}
+	}
+
+	// Verify IPs from prevResult are assigned.
+	zap.L().Info("checking link addresses from prevResult")
 	addrs, err := link.Addresses()
 	if err != nil {
 		return fmt.Errorf("check link %s: %w", link, err)
 	}
-	if !slices.ContainsFunc(addrs, func(a *net.IPNet) bool {
-		return a.String() == addr.String()
-	}) {
-		return fmt.Errorf("check link %s: address %s not found", link, addr)
+	for _, ipConf := range prevResult.IPs {
+		if ipConf.Interface == nil || *ipConf.Interface != ifIdx {
+			continue
+		}
+		ip := ipConf.Address
+		if !slices.ContainsFunc(addrs, func(a *net.IPNet) bool {
+			return a.String() == ip.String()
+		}) {
+			return fmt.Errorf("check link %s: address %s not found", link, ip.String())
+		}
+	}
+
+	// Verify routes from prevResult are installed.
+	zap.L().Info("checking link routes from prevResult")
+	routes, err := link.Routes()
+	if err != nil {
+		return fmt.Errorf("check link %s: %w", link, err)
+	}
+	for _, route := range prevResult.Routes {
+		dst := route.Dst
+		if !slices.ContainsFunc(routes, func(r *net.IPNet) bool {
+			return r.String() == dst.String()
+		}) {
+			return fmt.Errorf("check link %s: route %s not found", link, dst.String())
+		}
 	}
 
 	zap.L().Info("checking link public key")

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -24,25 +24,18 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 		return fmt.Errorf("get link: %w", err)
 	}
 
-	if err == nil {
-		// Interface already exists — reconfigure it.
-		zap.L().Info("reconfiguring existing wireguard link")
-		if err := reconfigure(link, addr, wg); err != nil {
-			return fmt.Errorf("reconfigure link %s: %w", link, err)
-		}
-	} else {
-		// Interface not found — create and set up fresh.
+	if err != nil {
 		zap.L().Info("creating wireguard link")
 		link, err = mgr.Create()
 		if err != nil {
 			return fmt.Errorf("create link: %w", err)
 		}
+	}
 
-		zap.L().Info("configuring wireguard link")
-		if err := setup(link, addr, wg); err != nil {
-			_ = mgr.Delete()
-			return fmt.Errorf("setup link %s: %w", link, err)
-		}
+	zap.L().Info("configuring wireguard link")
+	if err := setup(link, addrs, wg); err != nil {
+		_ = mgr.Delete()
+		return fmt.Errorf("setup link %s: %w", link, err)
 	}
 
 	zap.L().Info("wireguard link ready")
@@ -130,35 +123,23 @@ func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResu
 }
 
 func setup(link network.Link, addrs []*net.IPNet, conf *wgtypes.Config) error {
-	for _, addr := range addrs {
-		zap.L().Info("assigning address", zap.String("address", addr.String()))
-		if err := link.AssignAddress(addr); err != nil {
-			return fmt.Errorf("assign address %v: %w", addr, err)
-		}
-	}
-	return applyConfig(link, conf)
-}
-
-// reconfigure applies the desired configuration to an existing WireGuard link.
-// Unlike setup, it only assigns the address if not already present, since other
-// plugins in the chain may have already assigned addresses to the interface.
-func reconfigure(link network.Link, addr *net.IPNet, conf *wgtypes.Config) error {
-	zap.L().Info("checking existing addresses")
-	addrs, err := link.Addresses()
+	existing, err := link.Addresses()
 	if err != nil {
-		return fmt.Errorf("get addresses %v: %w", link, err)
+		return fmt.Errorf("get existing addresses: %w", err)
 	}
 
-	hasAddr := slices.ContainsFunc(addrs, func(a *net.IPNet) bool {
-		return a.String() == addr.String()
-	})
-	if !hasAddr {
+	for _, addr := range addrs {
+		if slices.ContainsFunc(existing, func(a *net.IPNet) bool {
+			return a.String() == addr.String()
+		}) {
+			continue
+		}
+
 		zap.L().Info("assigning address", zap.String("address", addr.String()))
 		if err := link.AssignAddress(addr); err != nil {
 			return fmt.Errorf("assign address %v: %w", addr, err)
 		}
 	}
-
 	return applyConfig(link, conf)
 }
 

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -94,15 +94,21 @@ func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResu
 		return fmt.Errorf("check link %s: no IPs from prevResult matched interface %s", link, ifName)
 	}
 
-	// Verify routes from prevResult are installed.
-	if len(prevResult.Routes) > 0 {
-		zap.L().Info("checking link routes from prevResult")
+	// Verify routes this plugin is responsible for (peer AllowedIPs) are installed.
+	// prevResult.Routes is not used here because it may include routes from other
+	// plugins on other interfaces, which would not be present on the WireGuard link.
+	var expectedRoutes []net.IPNet
+	for _, peer := range wg.Peers {
+		expectedRoutes = append(expectedRoutes, peer.AllowedIPs...)
+	}
+	if len(expectedRoutes) > 0 {
+		zap.L().Info("checking link routes from peer AllowedIPs")
 		routes, err := link.Routes()
 		if err != nil {
 			return fmt.Errorf("check link %s: %w", link, err)
 		}
-		for _, route := range prevResult.Routes {
-			dst := route.Dst
+		for i := range expectedRoutes {
+			dst := &expectedRoutes[i]
 			if !slices.ContainsFunc(routes, func(r *net.IPNet) bool {
 				return r.String() == dst.String()
 			}) {

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -58,6 +58,9 @@ func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResu
 	if err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
+	if prevResult == nil {
+		return fmt.Errorf("check: missing prevResult")
+	}
 	link, err := mgr.Get()
 	if err != nil {
 		return fmt.Errorf("check link: %w", err)
@@ -71,6 +74,9 @@ func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResu
 			break
 		}
 	}
+	if ifIdx == -1 {
+		return fmt.Errorf("check link %s: interface %s not found in prevResult", link, ifName)
+	}
 
 	// Verify IPs from prevResult are assigned.
 	zap.L().Info("checking link addresses from prevResult")
@@ -78,6 +84,7 @@ func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResu
 	if err != nil {
 		return fmt.Errorf("check link %s: %w", link, err)
 	}
+	ipValidated := false
 	for _, ipConf := range prevResult.IPs {
 		if ipConf.Interface == nil || *ipConf.Interface != ifIdx {
 			continue
@@ -88,20 +95,26 @@ func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResu
 		}) {
 			return fmt.Errorf("check link %s: address %s not found", link, ip.String())
 		}
+		ipValidated = true
+	}
+	if !ipValidated {
+		return fmt.Errorf("check link %s: no IPs from prevResult matched interface %s", link, ifName)
 	}
 
 	// Verify routes from prevResult are installed.
-	zap.L().Info("checking link routes from prevResult")
-	routes, err := link.Routes()
-	if err != nil {
-		return fmt.Errorf("check link %s: %w", link, err)
-	}
-	for _, route := range prevResult.Routes {
-		dst := route.Dst
-		if !slices.ContainsFunc(routes, func(r *net.IPNet) bool {
-			return r.String() == dst.String()
-		}) {
-			return fmt.Errorf("check link %s: route %s not found", link, dst.String())
+	if len(prevResult.Routes) > 0 {
+		zap.L().Info("checking link routes from prevResult")
+		routes, err := link.Routes()
+		if err != nil {
+			return fmt.Errorf("check link %s: %w", link, err)
+		}
+		for _, route := range prevResult.Routes {
+			dst := route.Dst
+			if !slices.ContainsFunc(routes, func(r *net.IPNet) bool {
+				return r.String() == dst.String()
+			}) {
+				return fmt.Errorf("check link %s: route %s not found", link, dst.String())
+			}
 		}
 	}
 

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/unstoppablemango/wireguard-cni/pkg/config"
 	"github.com/unstoppablemango/wireguard-cni/pkg/wireguard"
@@ -291,8 +290,10 @@ var _ = Describe("Check", func() {
 		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
+		_, wgRoute, _ := net.ParseCIDR(conf.Peers[0].AllowedIPs[0])
 		link := &fakeLink{
 			addresses: []*net.IPNet{addr},
+			routes:    []*net.IPNet{wgRoute},
 			publicKey: privKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
@@ -396,24 +397,14 @@ var _ = Describe("Check", func() {
 			publicKey: privKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
-		_, routeDst, _ := net.ParseCIDR("10.1.0.0/24")
-		ifIdx := 0
-		prevResult := &current.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*current.Interface{{Name: ifName}},
-			IPs: []*current.IPConfig{{
-				Interface: &ifIdx,
-				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
-			}},
-			Routes: []*cnitypes.Route{{Dst: *routeDst}},
-		}
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("check"))
 	})
 
-	It("returns error when route from prevResult is not installed", func() {
+	It("returns error when AllowedIPs route is not installed on the link", func() {
 		conf, privKey := newTestConfig()
 		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
@@ -424,52 +415,45 @@ var _ = Describe("Check", func() {
 			publicKey: privKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
-		_, routeDst, _ := net.ParseCIDR("10.1.0.0/24")
-		ifIdx := 0
-		prevResult := &current.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*current.Interface{{Name: ifName}},
-			IPs: []*current.IPConfig{{
-				Interface: &ifIdx,
-				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
-			}},
-			Routes: []*cnitypes.Route{{Dst: *routeDst}},
-		}
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("succeeds when all IPs and routes from prevResult are present", func() {
+	It("succeeds when all IPs and AllowedIPs routes are present on the link", func() {
 		conf, privKey := newTestConfig()
 		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
-		_, routeDst, _ := net.ParseCIDR("10.1.0.0/24")
+		_, wgRoute, _ := net.ParseCIDR(conf.Peers[0].AllowedIPs[0])
 		link := &fakeLink{
 			addresses: []*net.IPNet{addr},
-			routes:    []*net.IPNet{routeDst},
+			routes:    []*net.IPNet{wgRoute},
 			publicKey: privKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
-		ifIdx := 0
-		prevResult := &current.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*current.Interface{{Name: ifName}},
-			IPs: []*current.IPConfig{{
-				Interface: &ifIdx,
-				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
-			}},
-			Routes: []*cnitypes.Route{{Dst: *routeDst}},
-		}
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("validates a default IPv4 route (0.0.0.0/0) from prevResult", func() {
-		conf, privKey := newTestConfig()
+	It("validates route when peer AllowedIPs contains default route (0.0.0.0/0)", func() {
+		privKey, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+		peerKey, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+		conf := &config.Config{
+			PrivateKey: privKey.String(),
+			Peers: []config.PeerConfig{{
+				PublicKey:  peerKey.PublicKey().String(),
+				AllowedIPs: []string{"0.0.0.0/0"},
+			}},
+		}
+		conf.RuntimeConfig.IPs = []string{"10.0.0.1/24"}
+
 		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
@@ -480,45 +464,38 @@ var _ = Describe("Check", func() {
 			publicKey: privKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
-		ifIdx := 0
-		prevResult := &current.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*current.Interface{{Name: ifName}},
-			IPs: []*current.IPConfig{{
-				Interface: &ifIdx,
-				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
-			}},
-			Routes: []*cnitypes.Route{{Dst: *defaultRoute}},
-		}
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
-		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		err = wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("returns error when default IPv4 route from prevResult is not installed", func() {
-		conf, privKey := newTestConfig()
+	It("returns error when peer AllowedIPs default route (0.0.0.0/0) is not installed", func() {
+		privKey, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+		peerKey, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+		conf := &config.Config{
+			PrivateKey: privKey.String(),
+			Peers: []config.PeerConfig{{
+				PublicKey:  peerKey.PublicKey().String(),
+				AllowedIPs: []string{"0.0.0.0/0"},
+			}},
+		}
+		conf.RuntimeConfig.IPs = []string{"10.0.0.1/24"}
+
 		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
-		_, defaultRoute, _ := net.ParseCIDR("0.0.0.0/0")
 		link := &fakeLink{
 			addresses: []*net.IPNet{addr},
 			routes:    []*net.IPNet{},
 			publicKey: privKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
-		ifIdx := 0
-		prevResult := &current.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*current.Interface{{Name: ifName}},
-			IPs: []*current.IPConfig{{
-				Interface: &ifIdx,
-				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
-			}},
-			Routes: []*cnitypes.Route{{Dst: *defaultRoute}},
-		}
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
-		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		err = wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
@@ -528,8 +505,10 @@ var _ = Describe("Check", func() {
 		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
+		_, wgRoute, _ := net.ParseCIDR(conf.Peers[0].AllowedIPs[0])
 		link := &fakeLink{
 			addresses:    []*net.IPNet{addr},
+			routes:       []*net.IPNet{wgRoute},
 			publicKeyErr: errors.New("pubkey error"),
 		}
 		mgr := &fakeLinkManager{getLink: link}
@@ -546,8 +525,10 @@ var _ = Describe("Check", func() {
 		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
 		wrongKey, _ := wgtypes.GeneratePrivateKey()
+		_, wgRoute, _ := net.ParseCIDR(conf.Peers[0].AllowedIPs[0])
 		link := &fakeLink{
 			addresses: []*net.IPNet{addr},
+			routes:    []*net.IPNet{wgRoute},
 			publicKey: wrongKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -269,7 +269,8 @@ var _ = Describe("Add", func() {
 
 // newTestPrevResult builds a minimal prevResult with the given interface name and address.
 func newTestPrevResult(ifName, cidr string) *current.Result {
-	ip, ipnet, _ := net.ParseCIDR(cidr)
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	Expect(err).NotTo(HaveOccurred())
 	ifIdx := 0
 	return &current.Result{
 		CNIVersion: "1.0.0",

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -218,9 +218,8 @@ var _ = Describe("Add", func() {
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("get addresses"))
+		Expect(err).To(MatchError(ContainSubstring("get existing addresses")))
 		Expect(mgr.created).To(BeFalse())
-		Expect(mgr.deleted).To(BeFalse())
 	})
 
 	It("returns error when AssignAddress fails during reconfigure path", func() {
@@ -233,7 +232,7 @@ var _ = Describe("Add", func() {
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("assign address"))
+		Expect(err).To(MatchError(ContainSubstring("assign address")))
 		Expect(mgr.created).To(BeFalse())
 	})
 
@@ -277,12 +276,10 @@ func newTestPrevResult(ifName, cidr string) *current.Result {
 		Interfaces: []*current.Interface{
 			{Name: ifName, Sandbox: "/var/run/netns/test"},
 		},
-		IPs: []*current.IPConfig{
-			{
-				Interface: &ifIdx,
-				Address:   net.IPNet{IP: ip, Mask: ipnet.Mask},
-			},
-		},
+		IPs: []*current.IPConfig{{
+			Interface: &ifIdx,
+			Address:   net.IPNet{IP: ip, Mask: ipnet.Mask},
+		}},
 	}
 }
 

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -471,6 +471,61 @@ var _ = Describe("Check", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("validates a default IPv4 route (0.0.0.0/0) from prevResult", func() {
+		conf, privKey := newTestConfig()
+		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		addr.IP = ip
+		_, defaultRoute, _ := net.ParseCIDR("0.0.0.0/0")
+		link := &fakeLink{
+			addresses: []*net.IPNet{addr},
+			routes:    []*net.IPNet{defaultRoute},
+			publicKey: privKey.PublicKey(),
+		}
+		mgr := &fakeLinkManager{getLink: link}
+		ifIdx := 0
+		prevResult := &current.Result{
+			CNIVersion: "1.0.0",
+			Interfaces: []*current.Interface{{Name: ifName}},
+			IPs: []*current.IPConfig{{
+				Interface: &ifIdx,
+				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
+			}},
+			Routes: []*cnitypes.Route{{Dst: *defaultRoute}},
+		}
+
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns error when default IPv4 route from prevResult is not installed", func() {
+		conf, privKey := newTestConfig()
+		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		addr.IP = ip
+		_, defaultRoute, _ := net.ParseCIDR("0.0.0.0/0")
+		link := &fakeLink{
+			addresses: []*net.IPNet{addr},
+			routes:    []*net.IPNet{},
+			publicKey: privKey.PublicKey(),
+		}
+		mgr := &fakeLinkManager{getLink: link}
+		ifIdx := 0
+		prevResult := &current.Result{
+			CNIVersion: "1.0.0",
+			Interfaces: []*current.Interface{{Name: ifName}},
+			IPs: []*current.IPConfig{{
+				Interface: &ifIdx,
+				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
+			}},
+			Routes: []*cnitypes.Route{{Dst: *defaultRoute}},
+		}
+
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
 	It("returns error when PublicKey fails", func() {
 		conf, _ := newTestConfig()
 		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/unstoppablemango/wireguard-cni/pkg/config"
 	"github.com/unstoppablemango/wireguard-cni/pkg/wireguard"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
@@ -265,7 +267,27 @@ var _ = Describe("Add", func() {
 	})
 })
 
+// newTestPrevResult builds a minimal prevResult with the given interface name and address.
+func newTestPrevResult(ifName, cidr string) *current.Result {
+	ip, ipnet, _ := net.ParseCIDR(cidr)
+	ifIdx := 0
+	return &current.Result{
+		CNIVersion: "1.0.0",
+		Interfaces: []*current.Interface{
+			{Name: ifName, Sandbox: "/var/run/netns/test"},
+		},
+		IPs: []*current.IPConfig{
+			{
+				Interface: &ifIdx,
+				Address:   net.IPNet{IP: ip, Mask: ipnet.Mask},
+			},
+		},
+	}
+}
+
 var _ = Describe("Check", func() {
+	const ifName = "wg0"
+
 	It("succeeds when address and public key match", func() {
 		conf, privKey := newTestConfig()
 		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
@@ -276,16 +298,18 @@ var _ = Describe("Check", func() {
 			publicKey: privKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
+		prevResult := newTestPrevResult(ifName, conf.Address)
 
-		err := wireguard.Check(mgr, conf)
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("returns error when config is invalid", func() {
 		conf := &config.Config{}
 		mgr := &fakeLinkManager{}
+		prevResult := &current.Result{}
 
-		err := wireguard.Check(mgr, conf)
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("invalid configuration"))
 	})
@@ -293,8 +317,9 @@ var _ = Describe("Check", func() {
 	It("returns error when Get fails", func() {
 		conf, _ := newTestConfig()
 		mgr := &fakeLinkManager{getErr: errors.New("get failed")}
+		prevResult := newTestPrevResult(ifName, conf.Address)
 
-		err := wireguard.Check(mgr, conf)
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("check"))
 	})
@@ -303,20 +328,105 @@ var _ = Describe("Check", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{addressesErr: errors.New("addr error")}
 		mgr := &fakeLinkManager{getLink: link}
+		prevResult := newTestPrevResult(ifName, conf.Address)
 
-		err := wireguard.Check(mgr, conf)
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("check"))
 	})
 
-	It("returns error when address is not found on the link", func() {
+	It("returns error when IP from prevResult is not assigned on the link", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{addresses: []*net.IPNet{}}
 		mgr := &fakeLinkManager{getLink: link}
+		prevResult := newTestPrevResult(ifName, conf.Address)
 
-		err := wireguard.Check(mgr, conf)
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("returns error when Routes fails", func() {
+		conf, privKey := newTestConfig()
+		_, addr, _ := net.ParseCIDR(conf.Address)
+		ip, _, _ := net.ParseCIDR(conf.Address)
+		addr.IP = ip
+		link := &fakeLink{
+			addresses: []*net.IPNet{addr},
+			routesErr: errors.New("routes error"),
+			publicKey: privKey.PublicKey(),
+		}
+		mgr := &fakeLinkManager{getLink: link}
+		_, routeDst, _ := net.ParseCIDR("10.1.0.0/24")
+		ifIdx := 0
+		prevResult := &current.Result{
+			CNIVersion: "1.0.0",
+			Interfaces: []*current.Interface{{Name: ifName}},
+			IPs: []*current.IPConfig{{
+				Interface: &ifIdx,
+				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
+			}},
+			Routes: []*cnitypes.Route{{Dst: *routeDst}},
+		}
+
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("check"))
+	})
+
+	It("returns error when route from prevResult is not installed", func() {
+		conf, privKey := newTestConfig()
+		_, addr, _ := net.ParseCIDR(conf.Address)
+		ip, _, _ := net.ParseCIDR(conf.Address)
+		addr.IP = ip
+		link := &fakeLink{
+			addresses: []*net.IPNet{addr},
+			routes:    []*net.IPNet{},
+			publicKey: privKey.PublicKey(),
+		}
+		mgr := &fakeLinkManager{getLink: link}
+		_, routeDst, _ := net.ParseCIDR("10.1.0.0/24")
+		ifIdx := 0
+		prevResult := &current.Result{
+			CNIVersion: "1.0.0",
+			Interfaces: []*current.Interface{{Name: ifName}},
+			IPs: []*current.IPConfig{{
+				Interface: &ifIdx,
+				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
+			}},
+			Routes: []*cnitypes.Route{{Dst: *routeDst}},
+		}
+
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("succeeds when all IPs and routes from prevResult are present", func() {
+		conf, privKey := newTestConfig()
+		_, addr, _ := net.ParseCIDR(conf.Address)
+		ip, _, _ := net.ParseCIDR(conf.Address)
+		addr.IP = ip
+		_, routeDst, _ := net.ParseCIDR("10.1.0.0/24")
+		link := &fakeLink{
+			addresses: []*net.IPNet{addr},
+			routes:    []*net.IPNet{routeDst},
+			publicKey: privKey.PublicKey(),
+		}
+		mgr := &fakeLinkManager{getLink: link}
+		ifIdx := 0
+		prevResult := &current.Result{
+			CNIVersion: "1.0.0",
+			Interfaces: []*current.Interface{{Name: ifName}},
+			IPs: []*current.IPConfig{{
+				Interface: &ifIdx,
+				Address:   net.IPNet{IP: addr.IP, Mask: addr.Mask},
+			}},
+			Routes: []*cnitypes.Route{{Dst: *routeDst}},
+		}
+
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("returns error when PublicKey fails", func() {
@@ -329,8 +439,9 @@ var _ = Describe("Check", func() {
 			publicKeyErr: errors.New("pubkey error"),
 		}
 		mgr := &fakeLinkManager{getLink: link}
+		prevResult := newTestPrevResult(ifName, conf.Address)
 
-		err := wireguard.Check(mgr, conf)
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("check"))
 	})
@@ -346,8 +457,9 @@ var _ = Describe("Check", func() {
 			publicKey: wrongKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
+		prevResult := newTestPrevResult(ifName, conf.Address)
 
-		err := wireguard.Check(mgr, conf)
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("public key mismatch"))
 	})

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -298,7 +298,7 @@ var _ = Describe("Check", func() {
 			publicKey: privKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
-		prevResult := newTestPrevResult(ifName, conf.Address)
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).NotTo(HaveOccurred())
@@ -317,7 +317,7 @@ var _ = Describe("Check", func() {
 	It("returns error when Get fails", func() {
 		conf, _ := newTestConfig()
 		mgr := &fakeLinkManager{getErr: errors.New("get failed")}
-		prevResult := newTestPrevResult(ifName, conf.Address)
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
@@ -328,7 +328,7 @@ var _ = Describe("Check", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{addressesErr: errors.New("addr error")}
 		mgr := &fakeLinkManager{getLink: link}
-		prevResult := newTestPrevResult(ifName, conf.Address)
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
@@ -339,7 +339,7 @@ var _ = Describe("Check", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{addresses: []*net.IPNet{}}
 		mgr := &fakeLinkManager{getLink: link}
-		prevResult := newTestPrevResult(ifName, conf.Address)
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
@@ -348,8 +348,8 @@ var _ = Describe("Check", func() {
 
 	It("returns error when Routes fails", func() {
 		conf, privKey := newTestConfig()
-		_, addr, _ := net.ParseCIDR(conf.Address)
-		ip, _, _ := net.ParseCIDR(conf.Address)
+		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
 		link := &fakeLink{
 			addresses: []*net.IPNet{addr},
@@ -376,8 +376,8 @@ var _ = Describe("Check", func() {
 
 	It("returns error when route from prevResult is not installed", func() {
 		conf, privKey := newTestConfig()
-		_, addr, _ := net.ParseCIDR(conf.Address)
-		ip, _, _ := net.ParseCIDR(conf.Address)
+		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
 		link := &fakeLink{
 			addresses: []*net.IPNet{addr},
@@ -404,8 +404,8 @@ var _ = Describe("Check", func() {
 
 	It("succeeds when all IPs and routes from prevResult are present", func() {
 		conf, privKey := newTestConfig()
-		_, addr, _ := net.ParseCIDR(conf.Address)
-		ip, _, _ := net.ParseCIDR(conf.Address)
+		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
 		addr.IP = ip
 		_, routeDst, _ := net.ParseCIDR("10.1.0.0/24")
 		link := &fakeLink{
@@ -439,7 +439,7 @@ var _ = Describe("Check", func() {
 			publicKeyErr: errors.New("pubkey error"),
 		}
 		mgr := &fakeLinkManager{getLink: link}
-		prevResult := newTestPrevResult(ifName, conf.Address)
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())
@@ -457,7 +457,7 @@ var _ = Describe("Check", func() {
 			publicKey: wrongKey.PublicKey(),
 		}
 		mgr := &fakeLinkManager{getLink: link}
-		prevResult := newTestPrevResult(ifName, conf.Address)
+		prevResult := newTestPrevResult(ifName, conf.RuntimeConfig.IPs[0])
 
 		err := wireguard.Check(mgr, conf, ifName, prevResult)
 		Expect(err).To(HaveOccurred())

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -314,6 +314,47 @@ var _ = Describe("Check", func() {
 		Expect(err.Error()).To(ContainSubstring("invalid configuration"))
 	})
 
+	It("returns error when prevResult is nil", func() {
+		conf, _ := newTestConfig()
+		mgr := &fakeLinkManager{}
+
+		err := wireguard.Check(mgr, conf, ifName, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("missing prevResult"))
+	})
+
+	It("returns error when interface is not found in prevResult", func() {
+		conf, _ := newTestConfig()
+		link := &fakeLink{}
+		mgr := &fakeLinkManager{getLink: link}
+		prevResult := &current.Result{
+			CNIVersion: "1.0.0",
+			Interfaces: []*current.Interface{{Name: "other0"}},
+		}
+
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found in prevResult"))
+	})
+
+	It("returns error when no IPs from prevResult match the interface", func() {
+		conf, _ := newTestConfig()
+		_, addr, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		ip, _, _ := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		addr.IP = ip
+		link := &fakeLink{addresses: []*net.IPNet{addr}}
+		mgr := &fakeLinkManager{getLink: link}
+		prevResult := &current.Result{
+			CNIVersion: "1.0.0",
+			Interfaces: []*current.Interface{{Name: ifName}},
+			IPs:        []*current.IPConfig{},
+		}
+
+		err := wireguard.Check(mgr, conf, ifName, prevResult)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no IPs from prevResult matched"))
+	})
+
 	It("returns error when Get fails", func() {
 		conf, _ := newTestConfig()
 		mgr := &fakeLinkManager{getErr: errors.New("get failed")}


### PR DESCRIPTION
Check now verifies that all IPs and routes from the ADD result are still
present in the live network namespace, in addition to the existing public
key check. Adds Routes() to the Link interface backed by netlink.RouteList.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
