### PR TITLE
feat: reconfigure existing WireGuard interface instead of always creating

### DIFF
--- a/pkg/network/link.go
+++ b/pkg/network/link.go
@@ -1,10 +1,19 @@
 package network
 
 import (
+	"errors"
 	"net"
 
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
+
+// ErrLinkNotFound is returned by Get when the named network interface does not exist.
+var ErrLinkNotFound = errors.New("link not found")
+
+// IsNotFound reports whether err indicates that a network link was not found.
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrLinkNotFound)
+}
 
 // Link is a handle to a network interface. Methods correspond to the
 // operations the CNI plugin performs when configuring an interface.
@@ -31,6 +40,7 @@ type LinkManager interface {
 	Create() (Link, error)
 	// Delete removes the link. Idempotent: returns nil if not found.
 	Delete() error
-	// Get returns a handle to the existing link.
+	// Get returns a handle to the existing link. Returns ErrLinkNotFound
+	// (testable with IsNotFound) when the interface does not exist.
 	Get() (Link, error)
 }

--- a/pkg/network/linux.go
+++ b/pkg/network/linux.go
@@ -4,6 +4,7 @@ package network
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"syscall"
 
@@ -60,6 +61,9 @@ func (m netlinkManager) get() (netlink.Link, error) {
 
 func (m netlinkManager) Get() (Link, error) {
 	link, err := m.get()
+	if errors.As(err, &netlink.LinkNotFoundError{}) {
+		return nil, fmt.Errorf("%w: %w", ErrLinkNotFound, err)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/linux.go
+++ b/pkg/network/linux.go
@@ -4,7 +4,6 @@ package network
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"syscall"
 
@@ -62,7 +61,7 @@ func (m netlinkManager) get() (netlink.Link, error) {
 func (m netlinkManager) Get() (Link, error) {
 	link, err := m.get()
 	if errors.As(err, &netlink.LinkNotFoundError{}) {
-		return nil, fmt.Errorf("%w: %w", ErrLinkNotFound, err)
+		return nil, errors.Join(ErrLinkNotFound, err)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/wireguard/fake_test.go
+++ b/pkg/wireguard/fake_test.go
@@ -8,6 +8,11 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
+// notFoundError returns network.ErrLinkNotFound so that network.IsNotFound returns true.
+func notFoundError() error {
+	return network.ErrLinkNotFound
+}
+
 // fakeLink implements network.Link and records calls.
 type fakeLink struct {
 	assignAddressErr      error
@@ -22,9 +27,11 @@ type fakeLink struct {
 	assignedAddr   *net.IPNet
 	configuredConf *wgtypes.Config
 	addedRoutes    []*net.IPNet
+	assignCalled   bool
 }
 
 func (f *fakeLink) AssignAddress(addr *net.IPNet) error {
+	f.assignCalled = true
 	f.assignedAddr = addr
 	return f.assignAddressErr
 }
@@ -63,9 +70,11 @@ type fakeLinkManager struct {
 	getLink    network.Link
 	getErr     error
 	deleted    bool
+	created    bool
 }
 
 func (f *fakeLinkManager) Create() (network.Link, error) {
+	f.created = true
 	return f.createLink, f.createErr
 }
 

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -20,27 +20,27 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 	zap.L().Info("looking up wireguard link")
 	link, err := mgr.Get()
 	if err != nil && !network.IsNotFound(err) {
-		return fmt.Errorf("add link: %w", err)
+		return fmt.Errorf("get link: %w", err)
 	}
 
 	if err == nil {
 		// Interface already exists — reconfigure it.
 		zap.L().Info("reconfiguring existing wireguard link")
 		if err := reconfigure(link, addr, wg); err != nil {
-			return fmt.Errorf("add link %s: %w", link, err)
+			return fmt.Errorf("reconfigure link %s: %w", link, err)
 		}
 	} else {
 		// Interface not found — create and set up fresh.
 		zap.L().Info("creating wireguard link")
 		link, err = mgr.Create()
 		if err != nil {
-			return fmt.Errorf("add link: %w", err)
+			return fmt.Errorf("create link: %w", err)
 		}
 
 		zap.L().Info("configuring wireguard link")
 		if err := setup(link, addr, wg); err != nil {
 			_ = mgr.Delete()
-			return fmt.Errorf("add link %s: %w", link, err)
+			return fmt.Errorf("setup link %s: %w", link, err)
 		}
 	}
 
@@ -88,26 +88,7 @@ func setup(link network.Link, addr *net.IPNet, conf *wgtypes.Config) error {
 	if err := link.AssignAddress(addr); err != nil {
 		return fmt.Errorf("assign address %v: %w", addr, err)
 	}
-
-	zap.L().Info("applying wireguard configuration")
-	if err := link.ConfigureWireGuard(*conf); err != nil {
-		return fmt.Errorf("configure device %v: %w", link, err)
-	}
-
-	zap.L().Info("bringing link up")
-	if err := link.BringUp(); err != nil {
-		return fmt.Errorf("set link up: %w", err)
-	}
-
-	for _, peer := range conf.Peers {
-		for _, ip := range peer.AllowedIPs {
-			zap.L().Info("adding route", zap.String("dst", ip.String()))
-			if err := link.AddRoute(new(ip)); err != nil {
-				return fmt.Errorf("add route %v: %w", ip, err)
-			}
-		}
-	}
-	return nil
+	return applyConfig(link, conf)
 }
 
 // reconfigure applies the desired configuration to an existing WireGuard link.
@@ -130,6 +111,12 @@ func reconfigure(link network.Link, addr *net.IPNet, conf *wgtypes.Config) error
 		}
 	}
 
+	return applyConfig(link, conf)
+}
+
+// applyConfig configures the WireGuard device, brings the link up, and installs
+// per-peer routes. It is shared by setup (fresh interface) and reconfigure (existing).
+func applyConfig(link network.Link, conf *wgtypes.Config) error {
 	zap.L().Info("applying wireguard configuration")
 	if err := link.ConfigureWireGuard(*conf); err != nil {
 		return fmt.Errorf("configure device %v: %w", link, err)

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -17,16 +17,31 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	zap.L().Info("creating wireguard link")
-	link, err := mgr.Create()
-	if err != nil {
+	zap.L().Info("looking up wireguard link")
+	link, err := mgr.Get()
+	if err != nil && !network.IsNotFound(err) {
 		return fmt.Errorf("add link: %w", err)
 	}
 
-	zap.L().Info("configuring wireguard link")
-	if err := setup(link, addr, wg); err != nil {
-		_ = mgr.Delete()
-		return fmt.Errorf("add link %s: %w", link, err)
+	if err == nil {
+		// Interface already exists — reconfigure it.
+		zap.L().Info("reconfiguring existing wireguard link")
+		if err := reconfigure(link, addr, wg); err != nil {
+			return fmt.Errorf("add link %s: %w", link, err)
+		}
+	} else {
+		// Interface not found — create and set up fresh.
+		zap.L().Info("creating wireguard link")
+		link, err = mgr.Create()
+		if err != nil {
+			return fmt.Errorf("add link: %w", err)
+		}
+
+		zap.L().Info("configuring wireguard link")
+		if err := setup(link, addr, wg); err != nil {
+			_ = mgr.Delete()
+			return fmt.Errorf("add link %s: %w", link, err)
+		}
 	}
 
 	zap.L().Info("wireguard link ready")
@@ -72,6 +87,47 @@ func setup(link network.Link, addr *net.IPNet, conf *wgtypes.Config) error {
 	zap.L().Info("assigning address", zap.String("address", addr.String()))
 	if err := link.AssignAddress(addr); err != nil {
 		return fmt.Errorf("assign address %v: %w", addr, err)
+	}
+
+	zap.L().Info("applying wireguard configuration")
+	if err := link.ConfigureWireGuard(*conf); err != nil {
+		return fmt.Errorf("configure device %v: %w", link, err)
+	}
+
+	zap.L().Info("bringing link up")
+	if err := link.BringUp(); err != nil {
+		return fmt.Errorf("set link up: %w", err)
+	}
+
+	for _, peer := range conf.Peers {
+		for _, ip := range peer.AllowedIPs {
+			zap.L().Info("adding route", zap.String("dst", ip.String()))
+			if err := link.AddRoute(new(ip)); err != nil {
+				return fmt.Errorf("add route %v: %w", ip, err)
+			}
+		}
+	}
+	return nil
+}
+
+// reconfigure applies the desired configuration to an existing WireGuard link.
+// Unlike setup, it only assigns the address if not already present, since other
+// plugins in the chain may have already assigned addresses to the interface.
+func reconfigure(link network.Link, addr *net.IPNet, conf *wgtypes.Config) error {
+	zap.L().Info("checking existing addresses")
+	addrs, err := link.Addresses()
+	if err != nil {
+		return fmt.Errorf("get addresses %v: %w", link, err)
+	}
+
+	hasAddr := slices.ContainsFunc(addrs, func(a *net.IPNet) bool {
+		return a.String() == addr.String()
+	})
+	if !hasAddr {
+		zap.L().Info("assigning address", zap.String("address", addr.String()))
+		if err := link.AssignAddress(addr); err != nil {
+			return fmt.Errorf("assign address %v: %w", addr, err)
+		}
 	}
 
 	zap.L().Info("applying wireguard configuration")

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -209,6 +209,32 @@ var _ = Describe("Add", func() {
 		Expect(link.addedRoutes).To(HaveLen(4))
 	})
 
+	It("returns error when Addresses fails during reconfigure path without calling Create or Delete", func() {
+		conf, _ := newTestConfig()
+		link := &fakeLink{addressesErr: errors.New("addr error")}
+		mgr := &fakeLinkManager{getLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("get addresses"))
+		Expect(mgr.created).To(BeFalse())
+		Expect(mgr.deleted).To(BeFalse())
+	})
+
+	It("returns error when AssignAddress fails during reconfigure path", func() {
+		conf, _ := newTestConfig()
+		link := &fakeLink{
+			addresses:        []*net.IPNet{},
+			assignAddressErr: errors.New("assign failed"),
+		}
+		mgr := &fakeLinkManager{getLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("assign address"))
+		Expect(mgr.created).To(BeFalse())
+	})
+
 	It("adds routes for all peers and CIDRs during reconfigure path", func() {
 		privKey, err := wgtypes.GeneratePrivateKey()
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -71,13 +71,13 @@ var _ = Describe("Add", func() {
 
 	It("skips AssignAddress when reconfiguring and address already present", func() {
 		conf, _ := newTestConfig()
-		_, addr, _ := net.ParseCIDR(conf.Address)
-		ip, _, _ := net.ParseCIDR(conf.Address)
+		ip, addr, err := net.ParseCIDR(conf.RuntimeConfig.IPs[0])
+		Expect(err).NotTo(HaveOccurred())
 		addr.IP = ip
 		link := &fakeLink{addresses: []*net.IPNet{addr}}
 		mgr := &fakeLinkManager{getLink: link}
 
-		err := wireguard.Add(mgr, conf)
+		err = wireguard.Add(mgr, conf)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(link.assignCalled).To(BeFalse())
 	})
@@ -178,9 +178,12 @@ var _ = Describe("Add", func() {
 	})
 
 	It("adds routes for all peers and CIDRs during create path", func() {
-		privKey, _ := wgtypes.GeneratePrivateKey()
-		peer1Key, _ := wgtypes.GeneratePrivateKey()
-		peer2Key, _ := wgtypes.GeneratePrivateKey()
+		privKey, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+		peer1Key, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+		peer2Key, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
 		conf := &config.Config{
 			PrivateKey: privKey.String(),
 			Peers: []config.PeerConfig{
@@ -201,17 +204,19 @@ var _ = Describe("Add", func() {
 			createLink: link,
 		}
 
-		err := wireguard.Add(mgr, conf)
+		err = wireguard.Add(mgr, conf)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(link.addedRoutes).To(HaveLen(4))
 	})
 
 	It("adds routes for all peers and CIDRs during reconfigure path", func() {
-		privKey, _ := wgtypes.GeneratePrivateKey()
-		peer1Key, _ := wgtypes.GeneratePrivateKey()
-		peer2Key, _ := wgtypes.GeneratePrivateKey()
+		privKey, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+		peer1Key, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+		peer2Key, err := wgtypes.GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
 		conf := &config.Config{
-			Address:    "10.0.0.1/24",
 			PrivateKey: privKey.String(),
 			Peers: []config.PeerConfig{
 				{
@@ -224,10 +229,11 @@ var _ = Describe("Add", func() {
 				},
 			},
 		}
+		conf.RuntimeConfig.IPs = []string{"10.0.0.1/24"}
 		link := &fakeLink{}
 		mgr := &fakeLinkManager{getLink: link}
 
-		err := wireguard.Add(mgr, conf)
+		err = wireguard.Add(mgr, conf)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(link.addedRoutes).To(HaveLen(4))
 	})

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Add", func() {
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError("add link: unexpected error"))
+		Expect(err).To(MatchError("get link: unexpected error"))
 	})
 
 	It("returns error when Create fails", func() {
@@ -109,7 +109,7 @@ var _ = Describe("Add", func() {
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError("add link: create failed"))
+		Expect(err).To(MatchError("create link: create failed"))
 	})
 
 	It("deletes the link when setup fails after create", func() {

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -30,16 +30,56 @@ func newTestConfig() (*config.Config, wgtypes.Key) {
 }
 
 var _ = Describe("Add", func() {
-	It("creates the link and runs setup", func() {
+	It("creates the link and runs setup when interface does not exist", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{}
-		mgr := &fakeLinkManager{createLink: link}
+		mgr := &fakeLinkManager{
+			getErr:     notFoundError(),
+			createLink: link,
+		}
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr.created).To(BeTrue())
 		Expect(link.assignedAddr).NotTo(BeNil())
 		Expect(link.configuredConf).NotTo(BeNil())
 		Expect(link.addedRoutes).To(HaveLen(1))
+	})
+
+	It("reconfigures existing interface without calling Create", func() {
+		conf, _ := newTestConfig()
+		link := &fakeLink{}
+		mgr := &fakeLinkManager{getLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr.created).To(BeFalse())
+		Expect(link.configuredConf).NotTo(BeNil())
+		Expect(link.addedRoutes).To(HaveLen(1))
+	})
+
+	It("assigns address when reconfiguring and address not already present", func() {
+		conf, _ := newTestConfig()
+		link := &fakeLink{addresses: []*net.IPNet{}}
+		mgr := &fakeLinkManager{getLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.assignCalled).To(BeTrue())
+		Expect(link.assignedAddr).NotTo(BeNil())
+	})
+
+	It("skips AssignAddress when reconfiguring and address already present", func() {
+		conf, _ := newTestConfig()
+		_, addr, _ := net.ParseCIDR(conf.Address)
+		ip, _, _ := net.ParseCIDR(conf.Address)
+		addr.IP = ip
+		link := &fakeLink{addresses: []*net.IPNet{addr}}
+		mgr := &fakeLinkManager{getLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.assignCalled).To(BeFalse())
 	})
 
 	It("returns error when config is invalid", func() {
@@ -51,19 +91,34 @@ var _ = Describe("Add", func() {
 		Expect(err.Error()).To(ContainSubstring("invalid configuration"))
 	})
 
+	It("returns error when Get fails with non-not-found error", func() {
+		conf, _ := newTestConfig()
+		mgr := &fakeLinkManager{getErr: errors.New("unexpected error")}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("add link: unexpected error"))
+	})
+
 	It("returns error when Create fails", func() {
 		conf, _ := newTestConfig()
-		mgr := &fakeLinkManager{createErr: errors.New("create failed")}
+		mgr := &fakeLinkManager{
+			getErr:    notFoundError(),
+			createErr: errors.New("create failed"),
+		}
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("add link: create failed"))
 	})
 
-	It("deletes the link when setup fails", func() {
+	It("deletes the link when setup fails after create", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{assignAddressErr: errors.New("assign failed")}
-		mgr := &fakeLinkManager{createLink: link}
+		mgr := &fakeLinkManager{
+			getErr:     notFoundError(),
+			createLink: link,
+		}
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
@@ -71,46 +126,58 @@ var _ = Describe("Add", func() {
 		Expect(mgr.deleted).To(BeTrue())
 	})
 
-	It("returns error when AssignAddress fails", func() {
+	It("returns error when AssignAddress fails during create path", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{assignAddressErr: errors.New("addr error")}
-		mgr := &fakeLinkManager{createLink: link}
+		mgr := &fakeLinkManager{
+			getErr:     notFoundError(),
+			createLink: link,
+		}
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("assign address"))
 	})
 
-	It("returns error when ConfigureWireGuard fails", func() {
+	It("returns error when ConfigureWireGuard fails during create path", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{configureWireguardErr: errors.New("wg error")}
-		mgr := &fakeLinkManager{createLink: link}
+		mgr := &fakeLinkManager{
+			getErr:     notFoundError(),
+			createLink: link,
+		}
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("returns error when BringUp fails", func() {
+	It("returns error when BringUp fails during create path", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{bringUpErr: errors.New("up error")}
-		mgr := &fakeLinkManager{createLink: link}
+		mgr := &fakeLinkManager{
+			getErr:     notFoundError(),
+			createLink: link,
+		}
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("set link up"))
 	})
 
-	It("returns error when AddRoute fails", func() {
+	It("returns error when AddRoute fails during create path", func() {
 		conf, _ := newTestConfig()
 		link := &fakeLink{addRouteErr: errors.New("route error")}
-		mgr := &fakeLinkManager{createLink: link}
+		mgr := &fakeLinkManager{
+			getErr:     notFoundError(),
+			createLink: link,
+		}
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("add route"))
 	})
 
-	It("adds routes for all peers and CIDRs", func() {
+	It("adds routes for all peers and CIDRs during create path", func() {
 		privKey, _ := wgtypes.GeneratePrivateKey()
 		peer1Key, _ := wgtypes.GeneratePrivateKey()
 		peer2Key, _ := wgtypes.GeneratePrivateKey()
@@ -129,7 +196,36 @@ var _ = Describe("Add", func() {
 		}
 		conf.RuntimeConfig.IPs = []string{"10.0.0.1/24"}
 		link := &fakeLink{}
-		mgr := &fakeLinkManager{createLink: link}
+		mgr := &fakeLinkManager{
+			getErr:     notFoundError(),
+			createLink: link,
+		}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.addedRoutes).To(HaveLen(4))
+	})
+
+	It("adds routes for all peers and CIDRs during reconfigure path", func() {
+		privKey, _ := wgtypes.GeneratePrivateKey()
+		peer1Key, _ := wgtypes.GeneratePrivateKey()
+		peer2Key, _ := wgtypes.GeneratePrivateKey()
+		conf := &config.Config{
+			Address:    "10.0.0.1/24",
+			PrivateKey: privKey.String(),
+			Peers: []config.PeerConfig{
+				{
+					PublicKey:  peer1Key.PublicKey().String(),
+					AllowedIPs: []string{"10.1.0.0/24", "10.2.0.0/24"},
+				},
+				{
+					PublicKey:  peer2Key.PublicKey().String(),
+					AllowedIPs: []string{"10.3.0.0/24", "10.4.0.0/24"},
+				},
+			},
+		}
+		link := &fakeLink{}
+		mgr := &fakeLinkManager{getLink: link}
 
 		err := wireguard.Add(mgr, conf)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Per CNI chained plugins convention, attempt to find and reconfigure an
existing interface before creating a new one. Reconfiguration is
idempotent: address is only added if not already present, routes use
existing EEXIST-tolerant logic.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
