### PR TITLE
feat: add mac and bandwidth CNI capabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/vishvananda/netlink v1.3.1
 	go.uber.org/zap v1.27.1
+	golang.org/x/sys v0.40.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
@@ -56,7 +57,6 @@ require (
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.9.0 // indirect

--- a/pkg/cmd/cni_linux.go
+++ b/pkg/cmd/cni_linux.go
@@ -51,7 +51,7 @@ func Check(args *skel.CmdArgs) error {
 	logger(args).Info("cmdCheck")
 	conf, err := config.Parse(args.StdinData)
 	if err != nil {
-		return err
+		return fmt.Errorf("cmdCheck: %w", err)
 	}
 	if conf.PrevResult == nil {
 		return ErrPrevResult

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,15 @@ func (c *PeerConfig) ResolveUDPAddr() (*net.UDPAddr, error) {
 	return net.ResolveUDPAddr("udp", c.Endpoint)
 }
 
+// BandwidthEntry holds rate-limit parameters from runtimeConfig.bandwidth.
+// Rates are in bits per second; bursts are in bits.
+type BandwidthEntry struct {
+	IngressRate  uint64 `json:"ingressRate"`
+	IngressBurst uint64 `json:"ingressBurst"`
+	EgressRate   uint64 `json:"egressRate"`
+	EgressBurst  uint64 `json:"egressBurst"`
+}
+
 type Config struct {
 	types.PluginConf
 	RuntimeConfig struct {
@@ -33,6 +42,25 @@ type Config struct {
 	PrivateKey string       `json:"privateKey"`
 	ListenPort int          `json:"listenPort,omitempty"`
 	Peers      []PeerConfig `json:"peers"`
+
+	RuntimeConfig struct {
+		IPs       []string        `json:"ips,omitempty"`
+		MAC       string          `json:"mac,omitempty"`
+		Bandwidth *BandwidthEntry `json:"bandwidth,omitempty"`
+	} `json:"runtimeConfig,omitempty"`
+}
+
+// ParseMAC parses the MAC address from runtimeConfig.mac.
+// Returns nil, nil when no MAC is configured.
+func (c *Config) ParseMAC() (net.HardwareAddr, error) {
+	if c.RuntimeConfig.MAC == "" {
+		return nil, nil
+	}
+	mac, err := net.ParseMAC(c.RuntimeConfig.MAC)
+	if err != nil {
+		return nil, fmt.Errorf("invalid MAC address %q: %w", c.RuntimeConfig.MAC, err)
+	}
+	return mac, nil
 }
 
 func Parse(stdin []byte) (*Config, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,18 +36,14 @@ type BandwidthEntry struct {
 
 type Config struct {
 	types.PluginConf
-	RuntimeConfig struct {
-		IPs []string `json:"ips,omitempty"`
-	} `json:"runtimeConfig,omitempty"`
-	PrivateKey string       `json:"privateKey"`
-	ListenPort int          `json:"listenPort,omitempty"`
-	Peers      []PeerConfig `json:"peers"`
-
+	PrivateKey    string       `json:"privateKey"`
+	ListenPort    int          `json:"listenPort,omitempty"`
+	Peers         []PeerConfig `json:"peers"`
 	RuntimeConfig struct {
 		IPs       []string        `json:"ips,omitempty"`
 		MAC       string          `json:"mac,omitempty"`
 		Bandwidth *BandwidthEntry `json:"bandwidth,omitempty"`
-	} `json:"runtimeConfig,omitempty"`
+	} `json:"runtimeConfig"`
 }
 
 // ParseMAC parses the MAC address from runtimeConfig.mac.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"encoding/json"
+	"maps"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,11 +15,12 @@ import (
 )
 
 func newNetConfWithRuntimeConfig(privKey, peerPubKey, address string, rc map[string]any) []byte {
+	merged := map[string]any{"ips": []string{address}}
+	maps.Copy(merged, rc)
 	conf := map[string]any{
 		"cniVersion": "1.0.0",
 		"name":       "wg-test",
 		"type":       "wireguard-cni",
-		"address":    address,
 		"privateKey": privKey,
 		"peers": []map[string]any{
 			{
@@ -26,7 +28,7 @@ func newNetConfWithRuntimeConfig(privKey, peerPubKey, address string, rc map[str
 				"allowedIPs": []string{"10.0.0.0/8"},
 			},
 		},
-		"runtimeConfig": rc,
+		"runtimeConfig": merged,
 	}
 	b, _ := json.Marshal(conf)
 	return b
@@ -266,7 +268,7 @@ var _ = Describe("Result", func() {
 		Expect(result.Routes).To(BeEmpty())
 	})
 
-	It("uses only the first IP when multiple are provided", func() {
+	It("emits all IPs when multiple are provided", func() {
 		conf := configWithIPs("10.0.0.1/24", "10.0.0.2/24")
 
 		result, err := conf.Result(args)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,6 +13,25 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
+func newNetConfWithRuntimeConfig(privKey, peerPubKey, address string, rc map[string]any) []byte {
+	conf := map[string]any{
+		"cniVersion": "1.0.0",
+		"name":       "wg-test",
+		"type":       "wireguard-cni",
+		"address":    address,
+		"privateKey": privKey,
+		"peers": []map[string]any{
+			{
+				"publicKey":  peerPubKey,
+				"allowedIPs": []string{"10.0.0.0/8"},
+			},
+		},
+		"runtimeConfig": rc,
+	}
+	b, _ := json.Marshal(conf)
+	return b
+}
+
 var _ = Describe("Config", func() {
 	It("parses a valid configuration", func() {
 		privKey, err := wgtypes.GeneratePrivateKey()
@@ -265,5 +284,84 @@ var _ = Describe("Result", func() {
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("invalid CIDR address"))
+	})
+})
+
+var _ = Describe("ParseMAC", func() {
+	It("returns nil when no MAC is configured", func() {
+		conf := &config.Config{}
+
+		mac, err := conf.ParseMAC()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mac).To(BeNil())
+	})
+
+	It("parses a valid MAC address", func() {
+		conf := &config.Config{}
+		conf.RuntimeConfig.MAC = "02:11:22:33:44:55"
+
+		mac, err := conf.ParseMAC()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mac).To(Equal(net.HardwareAddr{0x02, 0x11, 0x22, 0x33, 0x44, 0x55}))
+	})
+
+	It("returns error for an invalid MAC string", func() {
+		conf := &config.Config{}
+		conf.RuntimeConfig.MAC = "not-a-mac"
+
+		_, err := conf.ParseMAC()
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid MAC address"))
+	})
+
+	It("parses MAC from runtimeConfig JSON", func() {
+		privKey, _ := wgtypes.GeneratePrivateKey()
+		peerKey, _ := wgtypes.GeneratePrivateKey()
+		stdin := newNetConfWithRuntimeConfig(privKey.String(), peerKey.PublicKey().String(), "10.0.0.1/24", map[string]any{
+			"mac": "02:ab:cd:ef:00:01",
+		})
+
+		conf, err := config.Parse(stdin)
+		Expect(err).NotTo(HaveOccurred())
+
+		mac, err := conf.ParseMAC()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mac).To(Equal(net.HardwareAddr{0x02, 0xab, 0xcd, 0xef, 0x00, 0x01}))
+	})
+})
+
+var _ = Describe("BandwidthEntry", func() {
+	It("parses bandwidth config from runtimeConfig JSON", func() {
+		privKey, _ := wgtypes.GeneratePrivateKey()
+		peerKey, _ := wgtypes.GeneratePrivateKey()
+		stdin := newNetConfWithRuntimeConfig(privKey.String(), peerKey.PublicKey().String(), "10.0.0.1/24", map[string]any{
+			"bandwidth": map[string]any{
+				"ingressRate":  1000000,
+				"ingressBurst": 2000000,
+				"egressRate":   500000,
+				"egressBurst":  1000000,
+			},
+		})
+
+		conf, err := config.Parse(stdin)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conf.RuntimeConfig.Bandwidth).NotTo(BeNil())
+		Expect(conf.RuntimeConfig.Bandwidth.IngressRate).To(Equal(uint64(1000000)))
+		Expect(conf.RuntimeConfig.Bandwidth.IngressBurst).To(Equal(uint64(2000000)))
+		Expect(conf.RuntimeConfig.Bandwidth.EgressRate).To(Equal(uint64(500000)))
+		Expect(conf.RuntimeConfig.Bandwidth.EgressBurst).To(Equal(uint64(1000000)))
+	})
+
+	It("bandwidth is nil when not set in runtimeConfig", func() {
+		privKey, _ := wgtypes.GeneratePrivateKey()
+		peerKey, _ := wgtypes.GeneratePrivateKey()
+		stdin := newNetConf(privKey.String(), peerKey.PublicKey().String(), "10.0.0.1/24")
+
+		conf, err := config.Parse(stdin)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conf.RuntimeConfig.Bandwidth).To(BeNil())
 	})
 })

--- a/pkg/network/link.go
+++ b/pkg/network/link.go
@@ -32,6 +32,11 @@ type Link interface {
 	PublicKey() (wgtypes.Key, error)
 	// Routes returns all routes currently installed via this link.
 	Routes() ([]*net.IPNet, error)
+	// SetMAC sets the hardware address of the link.
+	SetMAC(mac net.HardwareAddr) error
+	// SetBandwidth applies ingress and egress rate limits to the link.
+	// Rates are in bits per second; bursts are in bits.
+	SetBandwidth(ingressRate, ingressBurst, egressRate, egressBurst uint64) error
 }
 
 // LinkManager manages a single named network link. The link name is

--- a/pkg/network/linux.go
+++ b/pkg/network/linux.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 // New returns a LinkManager for the named network interface.
@@ -140,4 +141,81 @@ func (l *netlinkLink) Routes() ([]*net.IPNet, error) {
 		result = append(result, ipNet)
 	}
 	return result, nil
+}
+
+func (l *netlinkLink) SetMAC(mac net.HardwareAddr) error {
+	return netlink.LinkSetHardwareAddr(l.link, mac)
+}
+
+// SetBandwidth applies ingress and egress rate limits to the link using tc qdiscs.
+// Rates are in bits per second; bursts are in bits.
+// Egress limiting uses a TBF qdisc on the root.
+// Ingress limiting uses an ingress qdisc with a U32 filter and police action.
+func (l *netlinkLink) SetBandwidth(ingressRate, ingressBurst, egressRate, egressBurst uint64) error {
+	idx := l.link.Attrs().Index
+
+	if egressRate > 0 {
+		// Convert bits/s → bytes/s and bits → bytes.
+		rateBytes := egressRate / 8
+		burstBytes := uint32(egressBurst / 8) //nolint:gosec
+		// Limit: how many bytes can be queued — use burst as a sensible default.
+		limitBytes := burstBytes
+		if limitBytes == 0 {
+			// Fall back: ~100ms of traffic at the given rate.
+			limitBytes = uint32(rateBytes / 10) //nolint:gosec
+		}
+		tbf := &netlink.Tbf{
+			QdiscAttrs: netlink.QdiscAttrs{
+				LinkIndex: idx,
+				Handle:    netlink.MakeHandle(1, 0),
+				Parent:    netlink.HANDLE_ROOT,
+			},
+			Rate:   rateBytes,
+			Buffer: burstBytes,
+			Limit:  limitBytes,
+		}
+		if err := netlink.QdiscAdd(tbf); err != nil {
+			return err
+		}
+	}
+
+	if ingressRate > 0 {
+		// Add ingress qdisc.
+		ingress := &netlink.Ingress{
+			QdiscAttrs: netlink.QdiscAttrs{
+				LinkIndex: idx,
+				Handle:    netlink.MakeHandle(0xffff, 0),
+				Parent:    netlink.HANDLE_INGRESS,
+			},
+		}
+		if err := netlink.QdiscAdd(ingress); err != nil {
+			return err
+		}
+
+		// Convert bits/s → bytes/s and bits → bytes.
+		rateBytes := uint32(ingressRate / 8)  //nolint:gosec
+		burstBytes := uint32(ingressBurst / 8) //nolint:gosec
+
+		// Add U32 filter with police action to drop excess traffic.
+		police := netlink.NewPoliceAction()
+		police.Rate = rateBytes
+		police.Burst = burstBytes
+		police.ExceedAction = netlink.TC_POLICE_SHOT
+		police.NotExceedAction = netlink.TC_POLICE_OK
+
+		filter := &netlink.U32{
+			FilterAttrs: netlink.FilterAttrs{
+				LinkIndex: idx,
+				Parent:    netlink.MakeHandle(0xffff, 0),
+				Priority:  1,
+				Protocol:  unix.ETH_P_ALL,
+			},
+			Police: police,
+		}
+		if err := netlink.FilterAdd(filter); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/network/linux.go
+++ b/pkg/network/linux.go
@@ -4,6 +4,8 @@ package network
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"net"
 	"syscall"
 
@@ -152,17 +154,27 @@ func (l *netlinkLink) SetMAC(mac net.HardwareAddr) error {
 // Egress limiting uses a TBF qdisc on the root.
 // Ingress limiting uses an ingress qdisc with a U32 filter and police action.
 func (l *netlinkLink) SetBandwidth(ingressRate, ingressBurst, egressRate, egressBurst uint64) error {
+	const maxUint32 = uint64(math.MaxUint32)
 	idx := l.link.Attrs().Index
 
 	if egressRate > 0 {
 		// Convert bits/s → bytes/s and bits → bytes.
 		rateBytes := egressRate / 8
-		burstBytes := uint32(egressBurst / 8) //nolint:gosec
+		if rateBytes == 0 {
+			return fmt.Errorf("egress rate %d bps is too low (minimum 8 bps)", egressRate)
+		}
+		if egressBurst/8 > maxUint32 {
+			return fmt.Errorf("egress burst %d bits overflows uint32", egressBurst)
+		}
+		burstBytes := uint32(egressBurst / 8)
 		// Limit: how many bytes can be queued — use burst as a sensible default.
 		limitBytes := burstBytes
 		if limitBytes == 0 {
 			// Fall back: ~100ms of traffic at the given rate.
-			limitBytes = uint32(rateBytes / 10) //nolint:gosec
+			if rateBytes/10 > maxUint32 {
+				return fmt.Errorf("egress rate %d bps derived limit overflows uint32", egressRate)
+			}
+			limitBytes = uint32(rateBytes / 10)
 		}
 		tbf := &netlink.Tbf{
 			QdiscAttrs: netlink.QdiscAttrs{
@@ -174,13 +186,24 @@ func (l *netlinkLink) SetBandwidth(ingressRate, ingressBurst, egressRate, egress
 			Buffer: burstBytes,
 			Limit:  limitBytes,
 		}
-		if err := netlink.QdiscAdd(tbf); err != nil {
+		if err := netlink.QdiscReplace(tbf); err != nil {
 			return err
 		}
 	}
 
 	if ingressRate > 0 {
-		// Add ingress qdisc.
+		if ingressRate/8 > maxUint32 {
+			return fmt.Errorf("ingress rate %d bps overflows uint32", ingressRate)
+		}
+		rateBytes := ingressRate / 8
+		if rateBytes == 0 {
+			return fmt.Errorf("ingress rate %d bps is too low (minimum 8 bps)", ingressRate)
+		}
+		if ingressBurst/8 > maxUint32 {
+			return fmt.Errorf("ingress burst %d bits overflows uint32", ingressBurst)
+		}
+
+		// Add ingress qdisc; delete and retry if one already exists.
 		ingress := &netlink.Ingress{
 			QdiscAttrs: netlink.QdiscAttrs{
 				LinkIndex: idx,
@@ -189,17 +212,23 @@ func (l *netlinkLink) SetBandwidth(ingressRate, ingressBurst, egressRate, egress
 			},
 		}
 		if err := netlink.QdiscAdd(ingress); err != nil {
-			return err
+			if errors.Is(err, syscall.EEXIST) || errors.Is(err, unix.EEXIST) {
+				if delErr := netlink.QdiscDel(ingress); delErr != nil &&
+					!errors.Is(delErr, syscall.ENOENT) && !errors.Is(delErr, unix.ENOENT) {
+					return delErr
+				}
+				if addErr := netlink.QdiscAdd(ingress); addErr != nil {
+					return addErr
+				}
+			} else {
+				return err
+			}
 		}
-
-		// Convert bits/s → bytes/s and bits → bytes.
-		rateBytes := uint32(ingressRate / 8)  //nolint:gosec
-		burstBytes := uint32(ingressBurst / 8) //nolint:gosec
 
 		// Add U32 filter with police action to drop excess traffic.
 		police := netlink.NewPoliceAction()
-		police.Rate = rateBytes
-		police.Burst = burstBytes
+		police.Rate = uint32(rateBytes)
+		police.Burst = uint32(ingressBurst / 8)
 		police.ExceedAction = netlink.TC_POLICE_SHOT
 		police.NotExceedAction = netlink.TC_POLICE_OK
 

--- a/pkg/wireguard/fake_test.go
+++ b/pkg/wireguard/fake_test.go
@@ -25,11 +25,15 @@ type fakeLink struct {
 	publicKey             wgtypes.Key
 	routesErr             error
 	routes                []*net.IPNet
+	setMACErr             error
+	setBandwidthErr       error
 
 	assignedAddr   *net.IPNet
 	configuredConf *wgtypes.Config
 	addedRoutes    []*net.IPNet
 	assignCalled   bool
+	setMAC         net.HardwareAddr
+	setBandwidthCalled bool
 }
 
 func (f *fakeLink) AssignAddress(addr *net.IPNet) error {
@@ -62,6 +66,16 @@ func (f *fakeLink) PublicKey() (wgtypes.Key, error) {
 
 func (f *fakeLink) Routes() ([]*net.IPNet, error) {
 	return f.routes, f.routesErr
+}
+
+func (f *fakeLink) SetMAC(mac net.HardwareAddr) error {
+	f.setMAC = mac
+	return f.setMACErr
+}
+
+func (f *fakeLink) SetBandwidth(ingressRate, ingressBurst, egressRate, egressBurst uint64) error {
+	f.setBandwidthCalled = true
+	return f.setBandwidthErr
 }
 
 func (f *fakeLink) String() string {

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -27,12 +27,6 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 	link, err := mgr.Get()
 	if err != nil && !network.IsNotFound(err) {
 		return fmt.Errorf("get link: %w", err)
-    }
-    
-	zap.L().Info("creating wireguard link")
-	link, err := mgr.Create()
-	if err != nil {
-		return fmt.Errorf("add link: %w", err)
 	}
 
 	if err != nil {
@@ -43,11 +37,10 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 		}
 	}
 
-		zap.L().Info("configuring wireguard link")
-	if err := setup(link, addr, wg, mac); err != nil {
-			_ = mgr.Delete()
-			return fmt.Errorf("setup link %s: %w", link, err)
-		}
+	zap.L().Info("configuring wireguard link")
+	if err := setup(link, addrs, wg, mac); err != nil {
+		_ = mgr.Delete()
+		return fmt.Errorf("setup link %s: %w", link, err)
 	}
 
 	if bw := conf.RuntimeConfig.Bandwidth; bw != nil {
@@ -148,7 +141,7 @@ func Check(mgr network.LinkManager, conf *config.Config, ifName string, prevResu
 	return nil
 }
 
-func setup(link network.Link, addrs []*net.IPNet, conf *wgtypes.Config) error {
+func setup(link network.Link, addrs []*net.IPNet, conf *wgtypes.Config, mac net.HardwareAddr) error {
 	existing, err := link.Addresses()
 	if err != nil {
 		return fmt.Errorf("get existing addresses: %w", err)
@@ -166,12 +159,12 @@ func setup(link network.Link, addrs []*net.IPNet, conf *wgtypes.Config) error {
 			return fmt.Errorf("assign address %v: %w", addr, err)
 		}
 	}
-	return applyConfig(link, conf)
+	return applyConfig(link, conf, mac)
 }
 
 // applyConfig configures the WireGuard device, brings the link up, and installs
 // per-peer routes. It is shared by setup (fresh interface) and reconfigure (existing).
-func applyConfig(link network.Link, conf *wgtypes.Config) error {
+func applyConfig(link network.Link, conf *wgtypes.Config, mac net.HardwareAddr) error {
 	zap.L().Info("applying wireguard configuration")
 	if err := link.ConfigureWireGuard(*conf); err != nil {
 		return fmt.Errorf("configure device %v: %w", link, err)

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -43,17 +43,10 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 		}
 	}
 
-	zap.L().Info("configuring wireguard link")
-	if err := setup(link, addrs, wg); err != nil {
-		_ = mgr.Delete()
-		return fmt.Errorf("setup link %s: %w", link, err)
-	}
-
-	if mac != nil {
-		zap.L().Info("setting MAC address", zap.String("mac", mac.String()))
-		if err := link.SetMAC(mac); err != nil {
+		zap.L().Info("configuring wireguard link")
+	if err := setup(link, addr, wg, mac); err != nil {
 			_ = mgr.Delete()
-			return fmt.Errorf("set MAC %s: %w", mac, err)
+			return fmt.Errorf("setup link %s: %w", link, err)
 		}
 	}
 
@@ -182,6 +175,13 @@ func applyConfig(link network.Link, conf *wgtypes.Config) error {
 	zap.L().Info("applying wireguard configuration")
 	if err := link.ConfigureWireGuard(*conf); err != nil {
 		return fmt.Errorf("configure device %v: %w", link, err)
+	}
+
+	if mac != nil {
+		zap.L().Info("setting MAC address", zap.String("mac", mac.String()))
+		if err := link.SetMAC(mac); err != nil {
+			return fmt.Errorf("set MAC %s: %w", mac.String(), err)
+		}
 	}
 
 	zap.L().Info("bringing link up")

--- a/pkg/wireguard/plugin.go
+++ b/pkg/wireguard/plugin.go
@@ -18,10 +18,21 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	mac, err := conf.ParseMAC()
+	if err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	zap.L().Info("looking up wireguard link")
 	link, err := mgr.Get()
 	if err != nil && !network.IsNotFound(err) {
 		return fmt.Errorf("get link: %w", err)
+    }
+    
+	zap.L().Info("creating wireguard link")
+	link, err := mgr.Create()
+	if err != nil {
+		return fmt.Errorf("add link: %w", err)
 	}
 
 	if err != nil {
@@ -36,6 +47,22 @@ func Add(mgr network.LinkManager, conf *config.Config) error {
 	if err := setup(link, addrs, wg); err != nil {
 		_ = mgr.Delete()
 		return fmt.Errorf("setup link %s: %w", link, err)
+	}
+
+	if mac != nil {
+		zap.L().Info("setting MAC address", zap.String("mac", mac.String()))
+		if err := link.SetMAC(mac); err != nil {
+			_ = mgr.Delete()
+			return fmt.Errorf("set MAC %s: %w", mac, err)
+		}
+	}
+
+	if bw := conf.RuntimeConfig.Bandwidth; bw != nil {
+		zap.L().Info("applying bandwidth limits")
+		if err := link.SetBandwidth(bw.IngressRate, bw.IngressBurst, bw.EgressRate, bw.EgressBurst); err != nil {
+			_ = mgr.Delete()
+			return fmt.Errorf("set bandwidth: %w", err)
+		}
 	}
 
 	zap.L().Info("wireguard link ready")

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 func newTestConfigWithMAC(mac string) *config.Config {
-	privKey, _ := wgtypes.GeneratePrivateKey()
-	peerKey, _ := wgtypes.GeneratePrivateKey()
+	privKey, err := wgtypes.GeneratePrivateKey()
+	Expect(err).NotTo(HaveOccurred())
+	peerKey, err := wgtypes.GeneratePrivateKey()
+	Expect(err).NotTo(HaveOccurred())
 	conf := &config.Config{
 		PrivateKey: privKey.String(),
 		Peers: []config.PeerConfig{{
@@ -29,8 +31,10 @@ func newTestConfigWithMAC(mac string) *config.Config {
 }
 
 func newTestConfigWithBandwidth(bw *config.BandwidthEntry) *config.Config {
-	privKey, _ := wgtypes.GeneratePrivateKey()
-	peerKey, _ := wgtypes.GeneratePrivateKey()
+	privKey, err := wgtypes.GeneratePrivateKey()
+	Expect(err).NotTo(HaveOccurred())
+	peerKey, err := wgtypes.GeneratePrivateKey()
+	Expect(err).NotTo(HaveOccurred())
 	conf := &config.Config{
 		PrivateKey: privKey.String(),
 		Peers: []config.PeerConfig{{

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -13,6 +13,36 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
+func newTestConfigWithMAC(mac string) *config.Config {
+	privKey, _ := wgtypes.GeneratePrivateKey()
+	peerKey, _ := wgtypes.GeneratePrivateKey()
+	conf := &config.Config{
+		Address:    "10.0.0.1/24",
+		PrivateKey: privKey.String(),
+		Peers: []config.PeerConfig{{
+			PublicKey:  peerKey.PublicKey().String(),
+			AllowedIPs: []string{"10.1.0.0/24"},
+		}},
+	}
+	conf.RuntimeConfig.MAC = mac
+	return conf
+}
+
+func newTestConfigWithBandwidth(bw *config.BandwidthEntry) *config.Config {
+	privKey, _ := wgtypes.GeneratePrivateKey()
+	peerKey, _ := wgtypes.GeneratePrivateKey()
+	conf := &config.Config{
+		Address:    "10.0.0.1/24",
+		PrivateKey: privKey.String(),
+		Peers: []config.PeerConfig{{
+			PublicKey:  peerKey.PublicKey().String(),
+			AllowedIPs: []string{"10.1.0.0/24"},
+		}},
+	}
+	conf.RuntimeConfig.Bandwidth = bw
+	return conf
+}
+
 func newTestConfig() (*config.Config, wgtypes.Key) {
 	privKey, err := wgtypes.GeneratePrivateKey()
 	Expect(err).NotTo(HaveOccurred())
@@ -176,6 +206,105 @@ var _ = Describe("Add", func() {
 		err := wireguard.Add(mgr, conf)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("add route"))
+	})
+
+	It("sets MAC when runtimeConfig.mac is configured", func() {
+		conf := newTestConfigWithMAC("02:11:22:33:44:55")
+		link := &fakeLink{}
+		mgr := &fakeLinkManager{createLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.setMAC).To(Equal(net.HardwareAddr{0x02, 0x11, 0x22, 0x33, 0x44, 0x55}))
+	})
+
+	It("does not call SetMAC when no MAC is configured", func() {
+		conf, _ := newTestConfig()
+		link := &fakeLink{}
+		mgr := &fakeLinkManager{createLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.setMAC).To(BeNil())
+	})
+
+	It("returns error for invalid MAC address", func() {
+		conf := newTestConfigWithMAC("not-a-mac")
+		link := &fakeLink{}
+		mgr := &fakeLinkManager{createLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid configuration"))
+	})
+
+	It("returns error when SetMAC fails", func() {
+		conf := newTestConfigWithMAC("02:11:22:33:44:55")
+		link := &fakeLink{setMACErr: errors.New("mac error")}
+		mgr := &fakeLinkManager{createLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("set MAC"))
+	})
+
+	It("deletes the link when SetMAC fails", func() {
+		conf := newTestConfigWithMAC("02:11:22:33:44:55")
+		link := &fakeLink{setMACErr: errors.New("mac error")}
+		mgr := &fakeLinkManager{createLink: link}
+
+		_ = wireguard.Add(mgr, conf)
+		Expect(mgr.deleted).To(BeTrue())
+	})
+
+	It("applies bandwidth when runtimeConfig.bandwidth is configured", func() {
+		conf := newTestConfigWithBandwidth(&config.BandwidthEntry{
+			IngressRate:  1000000,
+			IngressBurst: 2000000,
+			EgressRate:   500000,
+			EgressBurst:  1000000,
+		})
+		link := &fakeLink{}
+		mgr := &fakeLinkManager{createLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.setBandwidthCalled).To(BeTrue())
+	})
+
+	It("does not call SetBandwidth when no bandwidth is configured", func() {
+		conf, _ := newTestConfig()
+		link := &fakeLink{}
+		mgr := &fakeLinkManager{createLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.setBandwidthCalled).To(BeFalse())
+	})
+
+	It("returns error when SetBandwidth fails", func() {
+		conf := newTestConfigWithBandwidth(&config.BandwidthEntry{
+			EgressRate:  1000000,
+			EgressBurst: 2000000,
+		})
+		link := &fakeLink{setBandwidthErr: errors.New("bw error")}
+		mgr := &fakeLinkManager{createLink: link}
+
+		err := wireguard.Add(mgr, conf)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("set bandwidth"))
+	})
+
+	It("deletes the link when SetBandwidth fails", func() {
+		conf := newTestConfigWithBandwidth(&config.BandwidthEntry{
+			EgressRate:  1000000,
+			EgressBurst: 2000000,
+		})
+		link := &fakeLink{setBandwidthErr: errors.New("bw error")}
+		mgr := &fakeLinkManager{createLink: link}
+
+		_ = wireguard.Add(mgr, conf)
+		Expect(mgr.deleted).To(BeTrue())
 	})
 
 	It("adds routes for all peers and CIDRs during create path", func() {

--- a/pkg/wireguard/plugin_test.go
+++ b/pkg/wireguard/plugin_test.go
@@ -17,13 +17,13 @@ func newTestConfigWithMAC(mac string) *config.Config {
 	privKey, _ := wgtypes.GeneratePrivateKey()
 	peerKey, _ := wgtypes.GeneratePrivateKey()
 	conf := &config.Config{
-		Address:    "10.0.0.1/24",
 		PrivateKey: privKey.String(),
 		Peers: []config.PeerConfig{{
 			PublicKey:  peerKey.PublicKey().String(),
 			AllowedIPs: []string{"10.1.0.0/24"},
 		}},
 	}
+	conf.RuntimeConfig.IPs = []string{"10.0.0.1/24"}
 	conf.RuntimeConfig.MAC = mac
 	return conf
 }
@@ -32,13 +32,13 @@ func newTestConfigWithBandwidth(bw *config.BandwidthEntry) *config.Config {
 	privKey, _ := wgtypes.GeneratePrivateKey()
 	peerKey, _ := wgtypes.GeneratePrivateKey()
 	conf := &config.Config{
-		Address:    "10.0.0.1/24",
 		PrivateKey: privKey.String(),
 		Peers: []config.PeerConfig{{
 			PublicKey:  peerKey.PublicKey().String(),
 			AllowedIPs: []string{"10.1.0.0/24"},
 		}},
 	}
+	conf.RuntimeConfig.IPs = []string{"10.0.0.1/24"}
 	conf.RuntimeConfig.Bandwidth = bw
 	return conf
 }


### PR DESCRIPTION
Implements the mac well-known capability (runtimeConfig.mac) to set the
hardware address on the WireGuard interface. Also implements bandwidth
limiting via runtimeConfig.bandwidth using tc qdiscs (TBF for egress,
ingress qdisc + U32 police filter for ingress rate limiting).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
